### PR TITLE
BoardConfigCommon: make all paths for toolchains use shell pwd instea…

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -46,8 +46,8 @@ TARGET_CPU_VARIANT := cortex-a53
 TARGET_USES_64_BIT_BINDER := true
 
 # Kernel Toolchain
-ifneq ($(wildcard $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-7.3),)
-  KERNEL_TOOLCHAIN := $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-7.3/bin
+ifneq ($(wildcard $(shell pwd)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-7.3),)
+  KERNEL_TOOLCHAIN := $(shell pwd)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-7.3/bin
   KERNEL_TOOLCHAIN_PREFIX := arm-eabi-
 endif
 

--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -45,6 +45,12 @@ TARGET_CPU_VARIANT := cortex-a53
 # Binder API version
 TARGET_USES_64_BIT_BINDER := true
 
+# Kernel Toolchain
+ifneq ($(wildcard $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-7.3),)
+  KERNEL_TOOLCHAIN := $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-7.3/bin
+  KERNEL_TOOLCHAIN_PREFIX := arm-eabi-
+endif
+
 # Kernel
 BOARD_KERNEL_CMDLINE := console=ttyHSL0,115200,n8 androidboot.console=ttyHSL0 androidboot.hardware=qcom msm_rtb.filter=0x3F ehci-hcd.park=3 vmalloc=400M androidboot.bootdevice=7824900.sdhci utags.blkdev=/dev/block/bootdevice/by-name/utags utags.backup=/dev/block/bootdevice/by-name/utagsBackup movablecore=160M
 BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive


### PR DESCRIPTION
…d of ANDROID_BUILD_TOP.

As you stated @Akianonymus.